### PR TITLE
Limit width of the blurred area

### DIFF
--- a/REFrostedViewController/REFrostedViewController.m
+++ b/REFrostedViewController/REFrostedViewController.m
@@ -267,6 +267,9 @@
         if (offset > self.view.frame.size.width)
             offset = self.view.frame.size.width;
         
+        if (offset > self.minimumChildViewWidth)
+            offset = self.minimumChildViewWidth;
+        
         if (offset < 0)
             return;
         


### PR DESCRIPTION
Hello,

I'm using REFrostedViewController in an iPad app and it looks promising. I have one problem (with a suggested pull request for fixing) with it though: On the iPad it makes a lot of sense to have a large value for the `.threshold` property so it won't take to much screen at a time. It then looks less ideal that you can pull out the blurred area over the entire screen. The enclosed pull request just makes the blurred area not go any further than the `(view width) - .threshold` (taking advantage of the `.minimumChildViewWidth` property).

This is partly a policy question so maybee this behaviour ought to be configurable?

Cheers, Jacob
