### PR TITLE
Only reset view if we want to animate

### DIFF
--- a/REFrostedViewController/REFrostedContainerViewController.m
+++ b/REFrostedViewController/REFrostedContainerViewController.m
@@ -96,24 +96,24 @@
     self.backgroundImageView.frame = self.view.bounds;
     self.frostedViewController.menuViewController.view.frame = self.containerView.bounds;
     
-    if (self.frostedViewController.direction == REFrostedViewControllerDirectionLeft) {
-        [self setContainerFrame:CGRectMake(- self.frostedViewController.calculatedMenuViewSize.width, 0, self.frostedViewController.calculatedMenuViewSize.width, self.frostedViewController.calculatedMenuViewSize.height)];
-    }
-    
-    if (self.frostedViewController.direction == REFrostedViewControllerDirectionRight) {
-        [self setContainerFrame:CGRectMake(self.view.frame.size.width, 0, self.frostedViewController.calculatedMenuViewSize.width, self.frostedViewController.calculatedMenuViewSize.height)];
-    }
-    
-    if (self.frostedViewController.direction == REFrostedViewControllerDirectionTop) {
-        [self setContainerFrame:CGRectMake(0, -self.frostedViewController.calculatedMenuViewSize.height, self.frostedViewController.calculatedMenuViewSize.width, self.frostedViewController.calculatedMenuViewSize.height)];
-    }
-    
-    if (self.frostedViewController.direction == REFrostedViewControllerDirectionBottom) {
-        [self setContainerFrame:CGRectMake(0, self.view.frame.size.height, self.frostedViewController.calculatedMenuViewSize.width, self.frostedViewController.calculatedMenuViewSize.height)];
-    }
-    
-    if (self.animateApperance)
+    if (self.animateApperance) {
+        if (self.frostedViewController.direction == REFrostedViewControllerDirectionLeft) {
+            [self setContainerFrame:CGRectMake(- self.frostedViewController.calculatedMenuViewSize.width, 0, self.frostedViewController.calculatedMenuViewSize.width, self.frostedViewController.calculatedMenuViewSize.height)];
+        }
+        
+        if (self.frostedViewController.direction == REFrostedViewControllerDirectionRight) {
+            [self setContainerFrame:CGRectMake(self.view.frame.size.width, 0, self.frostedViewController.calculatedMenuViewSize.width, self.frostedViewController.calculatedMenuViewSize.height)];
+        }
+        
+        if (self.frostedViewController.direction == REFrostedViewControllerDirectionTop) {
+            [self setContainerFrame:CGRectMake(0, -self.frostedViewController.calculatedMenuViewSize.height, self.frostedViewController.calculatedMenuViewSize.width, self.frostedViewController.calculatedMenuViewSize.height)];
+        }
+        
+        if (self.frostedViewController.direction == REFrostedViewControllerDirectionBottom) {
+            [self setContainerFrame:CGRectMake(0, self.view.frame.size.height, self.frostedViewController.calculatedMenuViewSize.width, self.frostedViewController.calculatedMenuViewSize.height)];
+        }
         [self show];
+    }
 }
 
 - (void)setContainerFrame:(CGRect)frame


### PR DESCRIPTION
I was running into an issue when I presented a VC in front of my frostViewController. When that view dismissed, the frostedViewController would reanimate. Setting the container's `animateApperance` BOOL didn't immediately fix the issue. But moving the view's frame settings inside that check fixed the issue.
