### PR TITLE
Added hooks to change the live blur background color.

### DIFF
--- a/REFrostedViewController/REFrostedContainerViewController.h
+++ b/REFrostedViewController/REFrostedContainerViewController.h
@@ -33,6 +33,7 @@
 @property (weak, readwrite, nonatomic) REFrostedViewController *frostedViewController;
 @property (assign, readwrite, nonatomic) BOOL animateApperance;
 @property (strong, readonly, nonatomic) UIView *containerView;
+@property (strong, readwrite, nonatomic) UIColor *liveBlurBackgroundColor;
 
 - (void)panGestureRecognized:(UIPanGestureRecognizer *)recognizer;
 - (void)hide;

--- a/REFrostedViewController/REFrostedContainerViewController.m
+++ b/REFrostedViewController/REFrostedContainerViewController.m
@@ -36,6 +36,7 @@
 @property (strong, readwrite, nonatomic) NSMutableArray *backgroundViews;
 @property (strong, readwrite, nonatomic) UIView *containerView;
 @property (assign, readwrite, nonatomic) CGPoint containerOrigin;
+@property (strong, readwrite, nonatomic) UIToolbar *backgroundToolbar;
 
 @end
 
@@ -68,10 +69,10 @@
     [self.view addSubview:self.containerView];
     
     if (self.frostedViewController.liveBlur) {
-        UIToolbar *toolbar = [[UIToolbar alloc] initWithFrame:self.view.bounds];
-        toolbar.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-        toolbar.barStyle = (UIBarStyle)self.frostedViewController.liveBlurBackgroundStyle;
-        [self.containerView addSubview:toolbar];
+        self.backgroundToolbar = [[UIToolbar alloc] initWithFrame:self.view.bounds];
+        self.backgroundToolbar.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+        self.backgroundToolbar.barStyle = (UIBarStyle)self.frostedViewController.liveBlurBackgroundStyle;
+        [self.containerView addSubview:self.backgroundToolbar];
     } else {
         self.backgroundImageView = [[UIImageView alloc] initWithFrame:self.view.bounds];
         [self.containerView addSubview:self.backgroundImageView];
@@ -112,6 +113,10 @@
         
         if (self.animateApperance)
             [self show];
+        
+        if (self.liveBlurBackgroundColor) {
+            self.backgroundToolbar.barTintColor = self.liveBlurBackgroundColor;
+        }
     }
 }
 

--- a/REFrostedViewController/REFrostedViewController.h
+++ b/REFrostedViewController/REFrostedViewController.h
@@ -54,7 +54,7 @@ typedef NS_ENUM(NSInteger, REFrostedViewControllerLiveBackgroundStyle) {
  * The default value is 0.3.
  */
 @property (assign, readwrite, nonatomic) CGFloat backgroundFadeAmount;
-@property (strong, readwrite, nonatomic) UIColor *blurTintColor; // Used only when live blur is off
+@property (strong, readwrite, nonatomic) UIColor *blurTintColor;
 @property (assign, readwrite, nonatomic) CGFloat blurRadius; // Used only when live blur is off
 @property (assign, readwrite, nonatomic) CGFloat blurSaturationDeltaFactor; // Used only when live blur is off
 @property (assign, readwrite, nonatomic) NSTimeInterval animationDuration;

--- a/REFrostedViewController/REFrostedViewController.m
+++ b/REFrostedViewController/REFrostedViewController.m
@@ -161,7 +161,7 @@
     self.automaticSize = NO;
 }
 
-- (void) setBlurTintColor:(UIColor *)blurTintColor {
+- (void)setBlurTintColor:(UIColor *)blurTintColor {
     _blurTintColor = blurTintColor;
     if (self.liveBlur) {
         if ([self.containerViewController isKindOfClass:[REFrostedContainerViewController class]]) {

--- a/REFrostedViewController/REFrostedViewController.m
+++ b/REFrostedViewController/REFrostedViewController.m
@@ -161,6 +161,16 @@
     self.automaticSize = NO;
 }
 
+- (void) setBlurTintColor:(UIColor *)blurTintColor {
+    _blurTintColor = blurTintColor;
+    if (self.liveBlur) {
+        if ([self.containerViewController isKindOfClass:[REFrostedContainerViewController class]]) {
+            REFrostedContainerViewController *containerViewController = (REFrostedContainerViewController*)self.containerViewController;
+            containerViewController.liveBlurBackgroundColor = blurTintColor;
+        }
+    }
+}
+
 #pragma mark -
 
 - (void)presentMenuViewController


### PR DESCRIPTION
Previously, the library only allowed for setting the background color if live blur was off, and toolbar would always use the value from `[UIToolbar appearance]`.

Now the user can `setBlurTintColor` in a live blur scenario.
