### PR TITLE
[bugfix] call hideMenuViewController before menuView added to containerV...

### DIFF
--- a/REFrostedViewController/REFrostedViewController.m
+++ b/REFrostedViewController/REFrostedViewController.m
@@ -199,6 +199,9 @@
 
 - (void)hideMenuViewControllerWithCompletionHandler:(void(^)(void))completionHandler
 {
+    if (!self.visible) {//when call hide menu before menuViewController added to containerViewController, the menuViewController will never added to containerViewController
+        return;
+    }
     if (!self.liveBlur) {
         self.containerViewController.screenshotImage = [[self.contentViewController.view re_screenshot] re_applyBlurWithRadius:self.blurRadius tintColor:self.blurTintColor saturationDeltaFactor:self.blurSaturationDeltaFactor maskImage:nil];
         [self.containerViewController refreshBackgroundImage];


### PR DESCRIPTION
when call `hideMenuViewControllerWithCompletionHandler` before `menuViewController` added to `containerViewController`, the `menuViewController` will never added to `containerViewController`
