### PR TITLE
Fix Issue #30 - Menu content view controller's size is not correct at first

### DIFF
--- a/REFrostedViewController/REFrostedContainerViewController.m
+++ b/REFrostedViewController/REFrostedContainerViewController.m
@@ -63,7 +63,7 @@
         [backgroundView addGestureRecognizer:tapRecognizer];
     }
     
-    self.containerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 250, self.view.frame.size.height)];
+    self.containerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, self.view.frame.size.height)];
     self.containerView.clipsToBounds = YES;
     [self.view addSubview:self.containerView];
     


### PR DESCRIPTION
Remove the magic number 250 for ```containerView``` width when created.

The ```menuSize``` property will next the correct size for container.