### PR TITLE
Specify an opaque background for or FrostedContainer

### DIFF
--- a/REFrostedViewController/REFrostedContainerViewController.m
+++ b/REFrostedViewController/REFrostedContainerViewController.m
@@ -74,6 +74,7 @@
         [self.containerView addSubview:toolbar];
     } else {
         self.backgroundImageView = [[UIImageView alloc] initWithFrame:self.view.bounds];
+        self.containerView.backgroundColor = self.frostedViewController.backgroundContainerColor;
         [self.containerView addSubview:self.backgroundImageView];
     }
     

--- a/REFrostedViewController/REFrostedViewController.h
+++ b/REFrostedViewController/REFrostedViewController.h
@@ -54,6 +54,7 @@ typedef NS_ENUM(NSInteger, REFrostedViewControllerLiveBackgroundStyle) {
  * The default value is 0.3.
  */
 @property (assign, readwrite, nonatomic) CGFloat backgroundFadeAmount;
+@property (assign, readwrite, nonatomic) UIColor *backgroundContainerColor;//take the priority insteed of liveBlur, if we want a specific opaque background
 @property (strong, readwrite, nonatomic) UIColor *blurTintColor; // Used only when live blur is off
 @property (assign, readwrite, nonatomic) CGFloat blurRadius; // Used only when live blur is off
 @property (assign, readwrite, nonatomic) CGFloat blurSaturationDeltaFactor; // Used only when live blur is off

--- a/REFrostedViewController/REFrostedViewController.m
+++ b/REFrostedViewController/REFrostedViewController.m
@@ -78,7 +78,7 @@
     _containerViewController = [[REFrostedContainerViewController alloc] init];
     _containerViewController.frostedViewController = self;
     _menuViewSize = CGSizeZero;
-    _liveBlur = REUIKitIsFlatMode();
+    _liveBlur = NO;
     _panGestureRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:_containerViewController action:@selector(panGestureRecognized:)];
     _automaticSize = YES;
 }
@@ -189,7 +189,7 @@
                                                  _menuViewSize.height > 0 ? _menuViewSize.height : self.contentViewController.view.frame.size.height);
     }
     
-    if (!self.liveBlur) {
+    if (self.liveBlur && !self.backgroundContainerColor) {
         if (REUIKitIsFlatMode() && !self.blurTintColor) {
             self.blurTintColor = [UIColor colorWithWhite:1 alpha:0.75f];
         }
@@ -205,7 +205,7 @@
     if (!self.visible) {//when call hide menu before menuViewController added to containerViewController, the menuViewController will never added to containerViewController
         return;
     }
-    if (!self.liveBlur) {
+    if (self.liveBlur && !self.frostedViewController.backgroundContainerColor) {
         self.containerViewController.screenshotImage = [[self.contentViewController.view re_screenshot] re_applyBlurWithRadius:self.blurRadius tintColor:self.blurTintColor saturationDeltaFactor:self.blurSaturationDeltaFactor maskImage:nil];
         [self.containerViewController refreshBackgroundImage];
     }
@@ -214,7 +214,7 @@
 
 - (void)resizeMenuViewControllerToSize:(CGSize)size
 {
-    if (!self.liveBlur) {
+    if (self.liveBlur && !self.frostedViewController.backgroundContainerColor) {
         self.containerViewController.screenshotImage = [[self.contentViewController.view re_screenshot] re_applyBlurWithRadius:self.blurRadius tintColor:self.blurTintColor saturationDeltaFactor:self.blurSaturationDeltaFactor maskImage:nil];
         [self.containerViewController refreshBackgroundImage];
     }


### PR DESCRIPTION
We have a problem if we don't want the blur management.

I added a `backgroundContainerColor` property to set an UIColor to the FrostedContainer.
Typically, if we want `liveBlur` we have to specify it. The `backgroundContainerColor` takes the priority to the `liveBlur` if the color is different to `nil`

Moreover, if we don't want blur, it doesn't call `re_applyBlurWithRadius` function which costs a lot of CPU in... Main thread :-1:  (before my request, the code test was if !liveBlur => call re_applyBlurWithRadius , it doesn't make sense ! Just let an opaque background.)

Open to discuss to improve my quick feature to be sure that it doesn't break other blur management.

So, the other issue which have to be fixed is to manage efficiently the GraphicBlur processing to a background queue or whatever.
